### PR TITLE
feat: defineNuxtPlugin migration

### DIFF
--- a/apps/web/content/cli/nuxt-bridge-migration-tools.md
+++ b/apps/web/content/cli/nuxt-bridge-migration-tools.md
@@ -91,8 +91,8 @@ npx @wattanx/nuxt-bridge-migration define-nuxt-middleware <files...>
 -   }
 - });
 
-+ import type { Context } from '@nuxt/types';
-+ export default ({ store, redirect }: Context) => {
++ import type { Middleware } from '@nuxt/types';
++ export default <Middleware> function({ store, redirect }) {
 +   if (!store.state.authenticated) {
 +     return redirect('/login')
 +   }

--- a/apps/web/content/cli/nuxt-bridge-migration-tools.md
+++ b/apps/web/content/cli/nuxt-bridge-migration-tools.md
@@ -98,3 +98,26 @@ npx @wattanx/nuxt-bridge-migration define-nuxt-middleware <files...>
 +   }
 + };
 ```
+
+### `defineNuxtPlugin` migration
+
+Remove `defineNuxtPlugin`.
+
+```bash
+npx @wattanx/nuxt-bridge-migration define-nuxt-plugin <files...>
+```
+
+```diff
+- import { defineNuxtPlugin } from '@nuxtjs/composition-api';
+- export default defineNuxtPlugin((ctx, inject) => {
+-   inject('hello', (msg) => console.log('Hello World'));
+- });
+
++ import type { Context, Inject } from '@nuxt/types';
++ export default (ctx: Context, inject: Inject) => {
++   inject('hello', (msg) => console.log('Hello World'));
++ };
+```
+
+> ⚠️ New format for nuxt 3 is not supported.
+> https://nuxt.com/docs/bridge/overview#new-plugins-format-optional

--- a/apps/web/content/cli/nuxt-bridge-migration-tools.md
+++ b/apps/web/content/cli/nuxt-bridge-migration-tools.md
@@ -113,8 +113,8 @@ npx @wattanx/nuxt-bridge-migration define-nuxt-plugin <files...>
 -   inject('hello', (msg) => console.log('Hello World'));
 - });
 
-+ import type { Context, Inject } from '@nuxt/types';
-+ export default (ctx: Context, inject: Inject) => {
++ import type { Plugin } from '@nuxt/types';
++ export default <Plugin> function(ctx, inject) {
 +   inject('hello', (msg) => console.log('Hello World'));
 + };
 ```

--- a/packages/nuxt-bridge-migration-tools/README.md
+++ b/packages/nuxt-bridge-migration-tools/README.md
@@ -111,8 +111,8 @@ npx @wattanx/nuxt-bridge-migration define-nuxt-plugin <files...>
 -   inject('hello', (msg) => console.log('Hello World'));
 - });
 
-+ import type { Context, Inject } from '@nuxt/types';
-+ export default (ctx: Context, inject: Inject) => {
++ import type { Plugin } from '@nuxt/types';
++ export default <Plugin> function(ctx, inject) {
 +   inject('hello', (msg) => console.log('Hello World'));
 + };
 ```

--- a/packages/nuxt-bridge-migration-tools/README.md
+++ b/packages/nuxt-bridge-migration-tools/README.md
@@ -96,3 +96,26 @@ npx @wattanx/nuxt-bridge-migration define-nuxt-middleware <files...>
 +   }
 + };
 ```
+
+### `defineNuxtPlugin` migration
+
+Remove `defineNuxtPlugin`.
+
+```bash
+npx @wattanx/nuxt-bridge-migration define-nuxt-plugin <files...>
+```
+
+```diff
+- import { defineNuxtPlugin } from '@nuxtjs/composition-api';
+- export default defineNuxtPlugin((ctx, inject) => {
+-   inject('hello', (msg) => console.log('Hello World'));
+- });
+
++ import type { Context, Inject } from '@nuxt/types';
++ export default (ctx: Context, inject: Inject) => {
++   inject('hello', (msg) => console.log('Hello World'));
++ };
+```
+
+> ⚠️ New format for nuxt 3 is not supported.
+> https://nuxt.com/docs/bridge/overview#new-plugins-format-optional

--- a/packages/nuxt-bridge-migration-tools/README.md
+++ b/packages/nuxt-bridge-migration-tools/README.md
@@ -89,8 +89,8 @@ npx @wattanx/nuxt-bridge-migration define-nuxt-middleware <files...>
 -   }
 - });
 
-+ import type { Context } from '@nuxt/types';
-+ export default ({ store, redirect }: Context) => {
++ import type { Middleware } from '@nuxt/types';
++ export default <Middleware> function({ store, redirect }) {
 +   if (!store.state.authenticated) {
 +     return redirect('/login')
 +   }

--- a/packages/nuxt-bridge-migration-tools/package.json
+++ b/packages/nuxt-bridge-migration-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wattanx/nuxt-bridge-migration",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A tool to support migration to Nuxt Bridge.",
   "main": "dist/index.js",
   "bin": {

--- a/packages/nuxt-bridge-migration-tools/src/commands/define-nuxt-plugin.ts
+++ b/packages/nuxt-bridge-migration-tools/src/commands/define-nuxt-plugin.ts
@@ -1,0 +1,28 @@
+import type { Arguments, Argv } from "yargs";
+import defineNuxtPlugin from "../transformations/define-nuxt-plugin";
+import { convertTargetFiles } from "../lib/convert-target-files";
+import { executeTransform } from "../handlers/execute-transform";
+
+type Options = {
+  targetFilePaths: string[];
+};
+
+export const command = "define-nuxt-plugin [targetFilePaths...]";
+export const desc = "Remove defineNuxtPlugin.";
+
+export const builder = (yargs: Argv<Options>): Argv<Options> =>
+  yargs.positional("targetFilePaths", {
+    array: true,
+    type: "string",
+    demandOption: true,
+    description:
+      "Path to the target vue file, which can be set with the glob pattern. eg: 'src/**/*.vue'",
+  } as const);
+
+export const handler = async (argv: Arguments<Options>): Promise<void> => {
+  const { targetFilePaths } = argv;
+
+  const targetFiles = await convertTargetFiles(targetFilePaths);
+
+  executeTransform(targetFiles, defineNuxtPlugin);
+};

--- a/packages/nuxt-bridge-migration-tools/src/transformations/define-nuxt-middleware.spec.ts
+++ b/packages/nuxt-bridge-migration-tools/src/transformations/define-nuxt-middleware.spec.ts
@@ -22,6 +22,27 @@ export default defineNuxtMiddleware(({ store, redirect }) => {
   expect(result).toBe(expected);
 });
 
+test("js async middleware", () => {
+  const source = `import { defineNuxtMiddleware } from "@nuxtjs/composition-api";
+export default defineNuxtMiddleware(async ({ store, redirect }) => {
+  if (!store.state.authenticated) {
+    return redirect('/login')
+  }
+});
+`;
+
+  const expected = `export default async ({ store, redirect }) => {
+  if (!store.state.authenticated) {
+    return redirect('/login')
+  }
+};`;
+
+  const result = applyTransform(transform, null, {
+    source,
+  });
+  expect(result).toBe(expected);
+});
+
 test("ts middleware", () => {
   const source = `import { defineNuxtMiddleware } from "@nuxtjs/composition-api";
 export default defineNuxtMiddleware(({ store, redirect }) => {
@@ -31,13 +52,36 @@ export default defineNuxtMiddleware(({ store, redirect }) => {
 });
 `;
 
-  const expected = `import type { Context } from '@nuxt/types';
-export default (
-  {
-    store,
-    redirect,
-  }: Context,
-) => {
+  const expected = `import type { Middleware } from '@nuxt/types';
+
+export default <Middleware> function({ store, redirect }) {
+  if (!store.state.authenticated) {
+    return redirect('/login')
+  }
+};`;
+
+  const result = applyTransform(
+    transform,
+    { lang: "ts" },
+    {
+      source,
+    }
+  );
+  expect(result).toBe(expected);
+});
+
+test("ts async middleware", () => {
+  const source = `import { defineNuxtMiddleware } from "@nuxtjs/composition-api";
+export default defineNuxtMiddleware(async ({ store, redirect }) => {
+  if (!store.state.authenticated) {
+    return redirect('/login')
+  }
+});
+`;
+
+  const expected = `import type { Middleware } from '@nuxt/types';
+
+export default <Middleware> async function({ store, redirect }) {
   if (!store.state.authenticated) {
     return redirect('/login')
   }

--- a/packages/nuxt-bridge-migration-tools/src/transformations/define-nuxt-middleware.ts
+++ b/packages/nuxt-bridge-migration-tools/src/transformations/define-nuxt-middleware.ts
@@ -1,3 +1,4 @@
+import { BlockStatement } from "jscodeshift";
 import { wrap, ASTTransformation } from "../wrapAstTransformation";
 
 export const convertDefineNuxtMiddleware: ASTTransformation<{
@@ -19,9 +20,11 @@ export const convertDefineNuxtMiddleware: ASTTransformation<{
     return;
   }
 
-  const callExpression = root.find(j.CallExpression, {
-    callee: {
-      name: "defineNuxtMiddleware",
+  const exportDefaultDeclaration = root.find(j.ExportDefaultDeclaration, {
+    declaration: {
+      callee: {
+        name: "defineNuxtMiddleware",
+      },
     },
   });
 
@@ -29,7 +32,7 @@ export const convertDefineNuxtMiddleware: ASTTransformation<{
     importDeclaration.forEach((x) => {
       j(x).replaceWith(
         j.importDeclaration(
-          [j.importSpecifier(j.identifier("Context"))],
+          [j.importSpecifier(j.identifier("Middleware"))],
           {
             type: "Literal",
             value: "@nuxt/types",
@@ -39,40 +42,50 @@ export const convertDefineNuxtMiddleware: ASTTransformation<{
       );
     });
 
-    callExpression.forEach((x) => {
-      const argument = x.node.arguments[0];
+    exportDefaultDeclaration.forEach((x) => {
+      const declaration = x.node.declaration;
 
-      if (argument.type === "ArrowFunctionExpression") {
-        const params = argument.params;
-        const body = argument.body;
+      if (declaration.type === "CallExpression") {
+        const argument = declaration.arguments[0];
 
-        const ctxParams = params[0];
+        if (argument.type === "ArrowFunctionExpression") {
+          const params = argument.params;
+          const body = argument.body as BlockStatement;
+          const isAsync = argument.async;
 
-        if (
-          ctxParams.type === "ObjectPattern" ||
-          ctxParams.type === "Identifier"
-        ) {
-          ctxParams.typeAnnotation = j.typeAnnotation(
-            j.genericTypeAnnotation(j.identifier("Context"), null)
+          const newFunc = j.functionExpression(null, params, body);
+          newFunc.async = isAsync;
+
+          j(x).replaceWith(
+            j.exportDeclaration(
+              true,
+              j.tsTypeAssertion(
+                j.tsTypeReference(j.identifier("Middleware"), null),
+                newFunc
+              )
+            )
           );
         }
-
-        j(x).replaceWith(j.arrowFunctionExpression(params, body));
       }
     });
+
     return;
   }
 
   importDeclaration.remove();
 
-  callExpression.forEach((x) => {
+  exportDefaultDeclaration.find(j.CallExpression).forEach((x) => {
     const argument = x.node.arguments[0];
 
     if (argument.type === "ArrowFunctionExpression") {
       const params = argument.params;
       const body = argument.body;
+      const isAsync = argument.async;
 
-      j(x).replaceWith(j.arrowFunctionExpression(params, body));
+      const newFunc = j.arrowFunctionExpression(params, body);
+      newFunc.async = isAsync;
+
+      j(x).replaceWith(newFunc);
     }
   });
 };

--- a/packages/nuxt-bridge-migration-tools/src/transformations/define-nuxt-plugin.spec.ts
+++ b/packages/nuxt-bridge-migration-tools/src/transformations/define-nuxt-plugin.spec.ts
@@ -18,6 +18,23 @@ export default defineNuxtPlugin((ctx, inject) => {
   expect(result).toBe(expected);
 });
 
+test("js async plugin", () => {
+  const source = `import { defineNuxtPlugin } from '@nuxtjs/composition-api';
+export default defineNuxtPlugin(async (ctx, inject) => {
+  inject('hello', (msg) => console.log('Hello World'));
+});
+`;
+
+  const expected = `export default async (ctx, inject) => {
+  inject('hello', (msg) => console.log('Hello World'));
+};`;
+
+  const result = applyTransform(transform, null, {
+    source,
+  });
+  expect(result).toBe(expected);
+});
+
 test("ts plugin", () => {
   const source = `import { defineNuxtPlugin } from '@nuxtjs/composition-api';
 export default defineNuxtPlugin((ctx, inject) => {
@@ -26,9 +43,33 @@ export default defineNuxtPlugin((ctx, inject) => {
 `;
 
   const expected = `import type { Plugin } from '@nuxt/types';
-export default <Plugin>function(ctx, inject) {
+
+export default <Plugin> function(ctx, inject) {
   inject('hello', (msg) => console.log('Hello World'));
-}`;
+};`;
+
+  const result = applyTransform(
+    transform,
+    { lang: "ts" },
+    {
+      source,
+    }
+  );
+  expect(result).toBe(expected);
+});
+
+test("ts async plugin", () => {
+  const source = `import { defineNuxtPlugin } from '@nuxtjs/composition-api';
+export default defineNuxtPlugin(async (ctx, inject) => {
+  inject('hello', (msg) => console.log('Hello World'));
+});
+`;
+
+  const expected = `import type { Plugin } from '@nuxt/types';
+
+export default <Plugin> async function(ctx, inject) {
+  inject('hello', (msg) => console.log('Hello World'));
+};`;
 
   const result = applyTransform(
     transform,
@@ -44,17 +85,11 @@ test("ts plugin with object params", () => {
   const source = `import { defineNuxtPlugin } from '@nuxtjs/composition-api';
 export default defineNuxtPlugin(({ app, store }, inject) => {
   inject('hello', (msg) => console.log('Hello World'));
-});
-`;
+});`;
 
   const expected = `import type { Plugin } from '@nuxt/types';
-export default <Plugin>function(
-  {
-    app,
-    store,
-  },
-  inject,
-) => {
+
+export default <Plugin> function({ app, store }, inject) {
   inject('hello', (msg) => console.log('Hello World'));
 };`;
 

--- a/packages/nuxt-bridge-migration-tools/src/transformations/define-nuxt-plugin.spec.ts
+++ b/packages/nuxt-bridge-migration-tools/src/transformations/define-nuxt-plugin.spec.ts
@@ -1,0 +1,69 @@
+import { applyTransform } from "jscodeshift/src/testUtils";
+import transform from "./define-nuxt-plugin";
+
+test("js plugin", () => {
+  const source = `import { defineNuxtPlugin } from '@nuxtjs/composition-api';
+export default defineNuxtPlugin((ctx, inject) => {
+  inject('hello', (msg) => console.log('Hello World'));
+});
+`;
+
+  const expected = `export default (ctx, inject) => {
+  inject('hello', (msg) => console.log('Hello World'));
+};`;
+
+  const result = applyTransform(transform, null, {
+    source,
+  });
+  expect(result).toBe(expected);
+});
+
+test("ts plugin", () => {
+  const source = `import { defineNuxtPlugin } from '@nuxtjs/composition-api';
+export default defineNuxtPlugin((ctx, inject) => {
+  inject('hello', (msg) => console.log('Hello World'));
+});
+`;
+
+  const expected = `import type { Plugin } from '@nuxt/types';
+export default <Plugin>function(ctx, inject) {
+  inject('hello', (msg) => console.log('Hello World'));
+}`;
+
+  const result = applyTransform(
+    transform,
+    { lang: "ts" },
+    {
+      source,
+    }
+  );
+  expect(result).toBe(expected);
+});
+
+test("ts plugin with object params", () => {
+  const source = `import { defineNuxtPlugin } from '@nuxtjs/composition-api';
+export default defineNuxtPlugin(({ app, store }, inject) => {
+  inject('hello', (msg) => console.log('Hello World'));
+});
+`;
+
+  const expected = `import type { Plugin } from '@nuxt/types';
+export default <Plugin>function(
+  {
+    app,
+    store,
+  },
+  inject,
+) => {
+  inject('hello', (msg) => console.log('Hello World'));
+};`;
+
+  const result = applyTransform(
+    transform,
+    { lang: "ts" },
+    {
+      source,
+    }
+  );
+  expect(result).toBe(expected);
+});

--- a/packages/nuxt-bridge-migration-tools/src/transformations/define-nuxt-plugin.ts
+++ b/packages/nuxt-bridge-migration-tools/src/transformations/define-nuxt-plugin.ts
@@ -1,0 +1,95 @@
+import { wrap, ASTTransformation } from "../wrapAstTransformation";
+
+export const convertDefineNuxtPlugin: ASTTransformation<{
+  lang?: string;
+}> = (context, options) => {
+  const { root, j } = context;
+
+  const importDeclaration = root.find(j.ImportDeclaration, {
+    specifiers: [
+      {
+        local: {
+          name: "defineNuxtPlugin",
+        },
+      },
+    ],
+  });
+
+  if (importDeclaration.length === 0) {
+    return;
+  }
+
+  const callExpression = root.find(j.CallExpression, {
+    callee: {
+      name: "defineNuxtPlugin",
+    },
+  });
+
+  if (options.lang === "ts") {
+    importDeclaration.forEach((x) => {
+      j(x).replaceWith(
+        j.importDeclaration(
+          [
+            j.importSpecifier(j.identifier("Context")),
+            j.importSpecifier(j.identifier("Inject")),
+          ],
+          {
+            type: "Literal",
+            value: "@nuxt/types",
+          },
+          "type"
+        )
+      );
+    });
+
+    callExpression.forEach((x) => {
+      const argument = x.node.arguments[0];
+
+      if (argument.type === "ArrowFunctionExpression") {
+        const params = argument.params;
+        const body = argument.body;
+
+        const ctxParams = params[0];
+
+        if (
+          ctxParams.type === "ObjectPattern" ||
+          ctxParams.type === "Identifier"
+        ) {
+          ctxParams.typeAnnotation = j.typeAnnotation(
+            j.genericTypeAnnotation(j.identifier("Context"), null)
+          );
+        }
+
+        const jnjectParams = params[1];
+
+        if (
+          jnjectParams.type === "ObjectPattern" ||
+          jnjectParams.type === "Identifier"
+        ) {
+          jnjectParams.typeAnnotation = j.typeAnnotation(
+            j.genericTypeAnnotation(j.identifier("Inject"), null)
+          );
+        }
+
+        j(x).replaceWith(j.arrowFunctionExpression(params, body));
+      }
+    });
+    return;
+  }
+
+  importDeclaration.remove();
+
+  callExpression.forEach((x) => {
+    const argument = x.node.arguments[0];
+
+    if (argument.type === "ArrowFunctionExpression") {
+      const params = argument.params;
+      const body = argument.body;
+
+      j(x).replaceWith(j.arrowFunctionExpression(params, body));
+    }
+  });
+};
+
+export default wrap(convertDefineNuxtPlugin);
+export const parser = "ts";


### PR DESCRIPTION
## ⚠️  Breaking Changes

`defineNuxtMiddleware` conversion results will change.

before
```ts
import type { Context } from '@nuxt/types';

export default ({ store, redirect }: Context) => {
  if (!store.state.authenticated) {
    return redirect('/login')
  }
}
```

after
```ts
import type { Middleware } from '@nuxt/types';

export default <Middleware> function({ store, redirect }) {
  if (!store.state.authenticated) {
    return redirect('/login')
  }
}
```