### PR TITLE
Fix script setup converter

### DIFF
--- a/packages/vue-script-setup-converter/src/lib/__snapshots__/convertSrc.test.ts.snap
+++ b/packages/vue-script-setup-converter/src/lib/__snapshots__/convertSrc.test.ts.snap
@@ -1,32 +1,37 @@
 // Vitest Snapshot v1
 
 exports[`lang=js > convert 1`] = `
-"import { defineComponent, toRefs, computed, ref } from \\"vue\\";
+"
+import { defineComponent, toRefs, computed, ref } from 'vue';
 const props = defineProps({
   msg: {
     type: String,
-    default: \\"HelloWorld\\",
-  },
-  foo: {
+    default: 'HelloWorld'
+  }, foo: {
     type: String,
     required: true,
-  },
+  }
 });
 const emit = defineEmits({ change: null });
+
 const { msg, foo } = toRefs(props);
-const newMsg = computed(() => msg.value + \\"- HelloWorld\\");
+const newMsg = computed(() => msg.value + '- HelloWorld');
 
 const count = ref(0);
 "
 `;
 
 exports[`lang=ts > type-base declaration 1`] = `
-"import { defineComponent, toRefs, computed, ref } from \\"vue\\";
-type Props = { msg?: string; foo: string };
-const props = withDefaults(defineProps<Props>(), { msg: \\"HelloWorld\\" });
-const emit = defineEmits<{ (e: \\"change\\", value: number): void }>();
+"
+import { defineComponent, toRefs, computed, ref } from 'vue';
+type Props = {
+  msg?: string;
+  foo: string;
+}; const props = withDefaults(defineProps<Props>(), { msg: 'HelloWorld' });
+const emit = defineEmits<{ (e: 'change', value: number): void; }>();
+
 const { msg, foo } = toRefs(props);
-const newMsg = computed(() => msg.value + \\"- HelloWorld\\");
+const newMsg = computed(() => msg.value + '- HelloWorld');
 
 const count = ref(0);
 emit(\\"change\\", 124);

--- a/packages/vue-script-setup-converter/src/lib/__snapshots__/convertSrc.test.ts.snap
+++ b/packages/vue-script-setup-converter/src/lib/__snapshots__/convertSrc.test.ts.snap
@@ -5,11 +5,11 @@ exports[`lang=js > convert 1`] = `
 const props = defineProps({
   msg: {
     type: String,
-    required: true,
     default: \\"HelloWorld\\",
   },
   foo: {
     type: String,
+    required: true,
   },
 });
 const emit = defineEmits({ change: null });
@@ -22,7 +22,7 @@ const count = ref(0);
 
 exports[`lang=ts > type-base declaration 1`] = `
 "import { defineComponent, toRefs, computed, ref } from \\"vue\\";
-type Props = { msg: string; foo?: string };
+type Props = { msg?: string; foo: string };
 const props = withDefaults(defineProps<Props>(), { msg: \\"HelloWorld\\" });
 const emit = defineEmits<{ (e: \\"change\\", value: number): void }>();
 const { msg, foo } = toRefs(props);

--- a/packages/vue-script-setup-converter/src/lib/converter/propsConverter.test.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/propsConverter.test.ts
@@ -6,7 +6,7 @@ import parserTypeScript from "prettier/parser-typescript";
 import { getNodeByKind } from "../helper";
 import { convertProps } from "./propsConverter";
 
-const source = `<script lang="ts">
+const source = `<script>
   import { defineComponent, toRefs, computed, ref } from 'vue';
   
   export default defineComponent({
@@ -135,6 +135,67 @@ test("type-based defineProps with require and default pattern", () => {
 
   const expected = `type Props = { msg?: string; foo: string };
 const props = withDefaults(defineProps<Props>(), { msg: "HelloWorld" });
+`;
+
+  expect(formatedText).toBe(expected);
+});
+
+test("custom validator", () => {
+  const source = `<script>
+  import { defineComponent, toRefs, computed, ref } from 'vue';
+  
+  export default defineComponent({
+    name: 'HelloWorld',
+    props: {
+      msg: {
+        type: String,
+        default: 'HelloWorld'
+      },
+      foo: {
+        type: String,
+        required: true,
+        validator(value) {
+          return ["success", "warning", "danger"].includes(value)
+        }
+      }
+    }
+  })
+  </script>`;
+  const {
+    descriptor: { script },
+  } = parse(source);
+
+  const project = new Project({
+    tsConfigFilePath: "tsconfig.json",
+    compilerOptions: {
+      target: ScriptTarget.Latest,
+    },
+  });
+
+  const sourceFile = project.createSourceFile("s.tsx", script?.content ?? "");
+
+  const callexpression = getNodeByKind(sourceFile, SyntaxKind.CallExpression);
+
+  const props = convertProps(callexpression as CallExpression);
+
+  const formatedText = prettier.format(props, {
+    parser: "typescript",
+    plugins: [parserTypeScript],
+  });
+
+  const expected = `const props = defineProps({
+  msg: {
+    type: String,
+    default: "HelloWorld",
+  },
+  foo: {
+    type: String,
+    required: true,
+    validator(value) {
+      return ["success", "warning", "danger"].includes(value);
+    },
+  },
+});
 `;
 
   expect(formatedText).toBe(expected);

--- a/packages/vue-script-setup-converter/src/lib/converter/propsConverter.test.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/propsConverter.test.ts
@@ -1,22 +1,33 @@
 import { expect, test } from "vitest";
-import {
-  CallExpression,
-  ScriptTarget,
-  SyntaxKind,
-  Project,
-  Node,
-} from "ts-morph";
+import { CallExpression, ScriptTarget, SyntaxKind, Project } from "ts-morph";
 import { parse } from "@vue/compiler-sfc";
 import prettier from "prettier";
 import parserTypeScript from "prettier/parser-typescript";
-import optionsApi from "../../samples/composition-api.txt?raw";
 import { getNodeByKind } from "../helper";
 import { convertProps } from "./propsConverter";
 
+const source = `<script lang="ts">
+  import { defineComponent, toRefs, computed, ref } from 'vue';
+  
+  export default defineComponent({
+    name: 'HelloWorld',
+    props: {
+      msg: {
+        type: String,
+        default: 'HelloWorld'
+      },
+      foo: {
+        type: String,
+        required: true
+      }
+    }
+  })
+  </script>`;
+
 test("defineProps", () => {
   const {
-    descriptor: { script, scriptSetup },
-  } = parse(optionsApi);
+    descriptor: { script },
+  } = parse(source);
 
   const project = new Project({
     tsConfigFilePath: "tsconfig.json",
@@ -39,13 +50,91 @@ test("defineProps", () => {
   const expected = `const props = defineProps({
   msg: {
     type: String,
-    required: true,
     default: "HelloWorld",
   },
   foo: {
     type: String,
+    required: true,
   },
 });
+`;
+
+  expect(formatedText).toBe(expected);
+});
+
+test("type-based defineProps", () => {
+  const {
+    descriptor: { script },
+  } = parse(source);
+
+  const project = new Project({
+    tsConfigFilePath: "tsconfig.json",
+    compilerOptions: {
+      target: ScriptTarget.Latest,
+    },
+  });
+
+  const sourceFile = project.createSourceFile("s.tsx", script?.content ?? "");
+
+  const callexpression = getNodeByKind(sourceFile, SyntaxKind.CallExpression);
+
+  const props = convertProps(callexpression as CallExpression, "ts");
+
+  const formatedText = prettier.format(props, {
+    parser: "typescript",
+    plugins: [parserTypeScript],
+  });
+
+  const expected = `type Props = { msg?: string; foo: string };
+const props = withDefaults(defineProps<Props>(), { msg: "HelloWorld" });
+`;
+
+  expect(formatedText).toBe(expected);
+});
+
+test("type-based defineProps with require and default pattern", () => {
+  const source = `<script lang="ts">
+  import { defineComponent, toRefs, computed, ref } from 'vue';
+  
+  export default defineComponent({
+    name: 'HelloWorld',
+    props: {
+      msg: {
+        type: String,
+        required: true,
+        default: 'HelloWorld'
+      },
+      foo: {
+        type: String,
+        required: true
+      }
+    }
+  })
+  </script>`;
+  const {
+    descriptor: { script },
+  } = parse(source);
+
+  const project = new Project({
+    tsConfigFilePath: "tsconfig.json",
+    compilerOptions: {
+      target: ScriptTarget.Latest,
+    },
+  });
+
+  const sourceFile = project.createSourceFile("s.tsx", script?.content ?? "");
+
+  const callexpression = getNodeByKind(sourceFile, SyntaxKind.CallExpression);
+
+  const props = convertProps(callexpression as CallExpression, "ts");
+
+  const formatedText = prettier.format(props, {
+    parser: "typescript",
+    plugins: [parserTypeScript],
+  });
+
+  const expected = `type Props = { msg?: string; foo: string };
+const props = withDefaults(defineProps<Props>(), { msg: "HelloWorld" });
 `;
 
   expect(formatedText).toBe(expected);

--- a/packages/vue-script-setup-converter/src/lib/converter/propsConverter.test.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/propsConverter.test.ts
@@ -140,6 +140,53 @@ const props = withDefaults(defineProps<Props>(), { msg: "HelloWorld" });
   expect(formatedText).toBe(expected);
 });
 
+test("type-based defineProps with default function", () => {
+  const source = `<script lang="ts">
+  import { defineComponent, toRefs, computed, ref } from 'vue';
+  
+  export default defineComponent({
+    name: 'HelloWorld',
+    props: {
+      foo: {
+        type: Object,
+        default() {
+          return { msg: "Hello World" }
+        }
+      }
+    }
+  })
+  </script>`;
+  const {
+    descriptor: { script },
+  } = parse(source);
+
+  const project = new Project({
+    tsConfigFilePath: "tsconfig.json",
+    compilerOptions: {
+      target: ScriptTarget.Latest,
+    },
+  });
+
+  const sourceFile = project.createSourceFile("s.tsx", script?.content ?? "");
+
+  const callexpression = getNodeByKind(sourceFile, SyntaxKind.CallExpression);
+
+  const props = convertProps(callexpression as CallExpression, "ts");
+
+  const formatedText = prettier.format(props, {
+    parser: "typescript",
+    plugins: [parserTypeScript],
+  });
+
+  const expected = `type Props = { foo?: { msg: string } };
+const props = withDefaults(defineProps<Props>(), {
+  foo: { msg: "Hello World" },
+});
+`;
+
+  expect(formatedText).toBe(expected);
+});
+
 test("custom validator", () => {
   const source = `<script>
   import { defineComponent, toRefs, computed, ref } from 'vue';

--- a/packages/vue-script-setup-converter/src/lib/converter/propsConverter.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/propsConverter.ts
@@ -99,7 +99,9 @@ const convertToTypeDefineProps = (props: PropType[]) => {
         return;
       }
       if (x.type === "object") {
-        return `${x.propertyName}${!x.required ? "?" : ""}: ${x.typeValue};`;
+        return `${x.propertyName}${
+          isOptional(x.required, x.defaultValue) ? "?" : ""
+        }: ${x.typeValue};`;
       }
       return `${x.propertyName}?: ${x.typeValue};`;
     })
@@ -224,6 +226,10 @@ const isTrueKeyword = (kind: SyntaxKind) => {
 
 const isFalseKeyword = (kind: number) => {
   return kind === SyntaxKind.FalseKeyword;
+};
+
+const isOptional = (required?: boolean, defaultValue?: string | boolean) => {
+  return !required || defaultValue !== undefined;
 };
 
 const typeMapping: Record<string, string> = {

--- a/packages/vue-script-setup-converter/src/lib/converter/setupConverter.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/setupConverter.ts
@@ -6,13 +6,13 @@ export const convertSetup = (node: CallExpression) => {
   const setupNode = getNodeByKind(node, SyntaxKind.MethodDeclaration);
 
   if (!setupNode) {
-    throw new Error("setup is not found.");
+    return "";
   }
 
   const blockNode = getNodeByKind(setupNode, SyntaxKind.Block);
 
   if (!blockNode) {
-    throw new Error("setup is not found.");
+    return "";
   }
 
   return blockNode

--- a/packages/vue-script-setup-converter/src/samples/composition-api-ts.txt
+++ b/packages/vue-script-setup-converter/src/samples/composition-api-ts.txt
@@ -9,11 +9,11 @@ export default defineComponent({
   props: {
     msg: {
       type: String,
-      required: true,
       default: 'HelloWorld'
     },
     foo: {
       type: String
+      required: true,
     }
   },
   setup(props, ctx) {

--- a/packages/vue-script-setup-converter/src/samples/composition-api.txt
+++ b/packages/vue-script-setup-converter/src/samples/composition-api.txt
@@ -9,11 +9,11 @@ export default defineComponent({
   props: {
     msg: {
       type: String,
-      required: true,
       default: 'HelloWorld'
     },
     foo: {
-      type: String
+      type: String,
+      required: true,
     }
   },
   setup(props, ctx) {


### PR DESCRIPTION
- support for default object
```ts
export default defineComponent({
  name: 'HelloWorld',
  props: {
    foo: {
      type: Object,
      default() {
        return { msg: "Hello World" }
      }
    }
  }
})
```

```ts
type Props = { foo?: { msg: string } };
const props = withDefaults(defineProps<Props>(), {
  foo: { msg: "Hello World" },
});
```