### PR TITLE
fix(vue-script-setup-converter): Check if it is undefined

### DIFF
--- a/packages/vue-script-setup-converter/src/lib/converter/propsConverter.test.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/propsConverter.test.ts
@@ -263,4 +263,31 @@ const props = defineProps<Props>();
 
     expect(output).toBe(expected);
   });
+
+  it("default value is boolean", () => {
+    const source = `<script lang="ts">
+  import { defineComponent, toRefs, computed, ref } from 'vue';
+  
+  export default defineComponent({
+    name: 'HelloWorld',
+    props: {
+      msg: {
+        type: String,
+        required: true
+      },
+      disabled: {
+        type: Boolean,
+        default: false
+      }
+    }
+  })
+  </script>`;
+    const output = parseScript(source, "ts");
+
+    const expected = `type Props = { msg: string; disabled?: boolean };
+const props = withDefaults(defineProps<Props>(), { disabled: false });
+`;
+
+    expect(output).toBe(expected);
+  });
 });

--- a/packages/vue-script-setup-converter/src/lib/converter/propsConverter.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/propsConverter.ts
@@ -40,7 +40,7 @@ const convertToDefineProps = (node: PropertyAssignment) => {
   return `const props = defineProps(${child.getFullText()});`;
 };
 
-// 以下 type-based declaration用
+// type-based declaration
 
 type PropType =
   | {
@@ -128,11 +128,13 @@ const convertToTypeDefineProps = (props: PropType[]) => {
 
   const defineProps = `const props = defineProps<Props>();`;
 
-  const hasDefault = props.find((x) => x.type === "object" && x.defaultValue);
+  const hasDefault = props.find(
+    (x) => x.type === "object" && x.defaultValue !== undefined
+  );
 
   const defaultValueParams = props
     .map((x) => {
-      if (x.type === "object" && x.defaultValue) {
+      if (x.type === "object" && x.defaultValue !== undefined) {
         return `${x.propertyName}: ${x.defaultValue}`;
       }
     })


### PR DESCRIPTION
Fixes: https://github.com/wattanx/wattanx-converter/issues/36

Because defaultValue may be a boolean, it must be checked to see if it is `undefined`.