### PR TITLE
fix(vue-script-setup-converter): remove new line

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": false
+}

--- a/packages/vue-script-setup-converter/src/lib/__snapshots__/convertSrc.test.ts.snap
+++ b/packages/vue-script-setup-converter/src/lib/__snapshots__/convertSrc.test.ts.snap
@@ -1,8 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`snapshot > defineNuxtComponent 1`] = `
-"
-import { defineNuxtComponent, useNuxtApp } from '#imports';
+"import { defineNuxtComponent, useNuxtApp } from '#imports';
 
 const { $client } = useNuxtApp();
 
@@ -13,8 +12,7 @@ const onSubmit = () => {
 `;
 
 exports[`snapshot > lang=js 1`] = `
-"
-import { defineComponent, toRefs, computed, ref } from 'vue';
+"import { defineComponent, toRefs, computed, ref } from 'vue';
 const props = defineProps({
   msg: {
     type: String,
@@ -34,8 +32,7 @@ const count = ref(0);
 `;
 
 exports[`snapshot > lang=ts 1`] = `
-"
-import { defineComponent, toRefs, computed, ref } from 'vue';
+"import { defineComponent, toRefs, computed, ref } from 'vue';
 type Props = {
   msg?: string;
   foo: string;

--- a/packages/vue-script-setup-converter/src/lib/convertSrc.test.ts
+++ b/packages/vue-script-setup-converter/src/lib/convertSrc.test.ts
@@ -1,8 +1,8 @@
-import { expect, describe, it } from 'vitest';
-import { convertSrc } from './convertSrc';
+import { expect, describe, it } from "vitest";
+import { convertSrc } from "./convertSrc";
 
-describe('snapshot', () => {
-  it('lang=js', () => {
+describe("snapshot", () => {
+  it("lang=js", () => {
     const output = convertSrc(`<script>
 import { defineComponent, toRefs, computed, ref } from 'vue';
 
@@ -37,7 +37,7 @@ export default defineComponent({
     expect(output).toMatchSnapshot();
   });
 
-  it('lang=ts', () => {
+  it("lang=ts", () => {
     const output = convertSrc(`<script lang="ts">
 import { defineComponent, toRefs, computed, ref } from 'vue';
 
@@ -73,7 +73,7 @@ export default defineComponent({
     expect(output).toMatchSnapshot();
   });
 
-  it('defineNuxtComponent', () => {
+  it("defineNuxtComponent", () => {
     const output = convertSrc(`<script lang="ts">
 import { defineNuxtComponent, useNuxtApp } from '#imports';
 
@@ -96,7 +96,7 @@ export default defineNuxtComponent({
     expect(output).toMatchSnapshot();
   });
 
-  it('empty setup context', () => {
+  it("empty setup context", () => {
     const output = convertSrc(`<script lang="ts">
 import { defineComponent, toRefs, computed } from 'vue';
 
@@ -120,8 +120,7 @@ export default defineComponent({
 </script>`);
     expect(output).toMatchInlineSnapshot(
       `
-      "
-      import { defineComponent, toRefs, computed } from 'vue';
+      "import { defineComponent, toRefs, computed } from 'vue';
       type Props = { msg?: string; }; const props = withDefaults(defineProps<Props>(), { msg: 'HelloWorld' });
 
       const { msg } = toRefs(props);
@@ -131,8 +130,9 @@ export default defineComponent({
     );
   });
 
-  it('props no toRefs', () => {
+  it("props no toRefs", () => {
     const output = convertSrc(`<script lang="ts">
+    import type { PropType } from 'vue';
 import { defineComponent, computed } from 'vue';
 
 export default defineComponent({
@@ -154,7 +154,7 @@ export default defineComponent({
 </script>`);
     expect(output).toMatchInlineSnapshot(
       `
-      "
+      "import type { PropType } from 'vue';
       import { defineComponent, computed } from 'vue';
       type Props = { msg?: string; }; const props = withDefaults(defineProps<Props>(), { msg: 'HelloWorld' });
 

--- a/packages/vue-script-setup-converter/src/lib/convertSrc.test.ts
+++ b/packages/vue-script-setup-converter/src/lib/convertSrc.test.ts
@@ -1,8 +1,8 @@
-import { expect, describe, it } from "vitest";
-import { convertSrc } from "./convertSrc";
+import { expect, describe, it } from 'vitest';
+import { convertSrc } from './convertSrc';
 
-describe("snapshot", () => {
-  it("lang=js", () => {
+describe('snapshot', () => {
+  it('lang=js', () => {
     const output = convertSrc(`<script>
 import { defineComponent, toRefs, computed, ref } from 'vue';
 
@@ -37,7 +37,7 @@ export default defineComponent({
     expect(output).toMatchSnapshot();
   });
 
-  it("lang=ts", () => {
+  it('lang=ts', () => {
     const output = convertSrc(`<script lang="ts">
 import { defineComponent, toRefs, computed, ref } from 'vue';
 
@@ -73,7 +73,7 @@ export default defineComponent({
     expect(output).toMatchSnapshot();
   });
 
-  it("defineNuxtComponent", () => {
+  it('defineNuxtComponent', () => {
     const output = convertSrc(`<script lang="ts">
 import { defineNuxtComponent, useNuxtApp } from '#imports';
 
@@ -96,7 +96,7 @@ export default defineNuxtComponent({
     expect(output).toMatchSnapshot();
   });
 
-  it("empty setup context", () => {
+  it('empty setup context', () => {
     const output = convertSrc(`<script lang="ts">
 import { defineComponent, toRefs, computed } from 'vue';
 
@@ -118,14 +118,16 @@ export default defineComponent({
   }
 })
 </script>`);
-    expect(output).toBe(
+    expect(output).toMatchInlineSnapshot(
       `
-import { defineComponent, toRefs, computed } from 'vue';
-type Props = { msg?: string; }; const props = withDefaults(defineProps<Props>(), { msg: 'HelloWorld' });
+      "
+      import { defineComponent, toRefs, computed } from 'vue';
+      type Props = { msg?: string; }; const props = withDefaults(defineProps<Props>(), { msg: 'HelloWorld' });
 
-const { msg } = toRefs(props);
-const newMsg = computed(() => msg.value + '- HelloWorld');
-`
+      const { msg } = toRefs(props);
+      const newMsg = computed(() => msg.value + '- HelloWorld');
+      "
+    `
     );
   });
 
@@ -150,13 +152,15 @@ export default defineComponent({
   }
 })
 </script>`);
-    expect(output).toBe(
+    expect(output).toMatchInlineSnapshot(
       `
-import { defineComponent, computed } from 'vue';
-type Props = { msg?: string; }; const props = withDefaults(defineProps<Props>(), { msg: 'HelloWorld' });
+      "
+      import { defineComponent, computed } from 'vue';
+      type Props = { msg?: string; }; const props = withDefaults(defineProps<Props>(), { msg: 'HelloWorld' });
 
-const newMsg = computed(() => props.msg + '- HelloWorld');
-`
+      const newMsg = computed(() => props.msg + '- HelloWorld');
+      "
+    `
     );
-  })
+  });
 });

--- a/packages/vue-script-setup-converter/src/lib/convertSrc.ts
+++ b/packages/vue-script-setup-converter/src/lib/convertSrc.ts
@@ -50,7 +50,7 @@ export const convertSrc = (input: string) => {
     sourceFile
       .getStatements()
       .filter((state) => !Node.isExportAssignment(state))
-      .map((x) => x.getFullText())
+      .map((x) => x.getText())
   );
 
   statements.addStatements(props);


### PR DESCRIPTION
When converted to script setup, the `import statement` contains a new line.
I want to remove it because it is unnecessary.