### PR TITLE
feat: convert to defineAsyncComponent

### DIFF
--- a/packages/vue-script-setup-converter/package.json
+++ b/packages/vue-script-setup-converter/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@vue/compiler-sfc": "^3.2.40",
-    "@wattanx/converter-utils": "*"
+    "@wattanx/converter-utils": "*",
+    "knitwork": "^1.1.0"
   }
 }

--- a/packages/vue-script-setup-converter/src/lib/__snapshots__/convertSrc.test.ts.snap
+++ b/packages/vue-script-setup-converter/src/lib/__snapshots__/convertSrc.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`snapshot > defineNuxtComponent 1`] = `
-"import { useNuxtApp } from '#imports';
+"import { useNuxtApp } from "#imports";
 definePageMeta({
   name: 'HelloWorld', layout: 'test-layout', middleware: 'test-middleware'
 });
@@ -15,7 +15,7 @@ const onSubmit = () => {
 `;
 
 exports[`snapshot > lang=js 1`] = `
-"import { toRefs, computed, ref } from 'vue';
+"import { toRefs, computed, ref } from "vue";
 const props = defineProps({
   msg: {
     type: String,
@@ -35,7 +35,7 @@ const count = ref(0);
 `;
 
 exports[`snapshot > lang=ts 1`] = `
-"import { toRefs, computed, ref } from 'vue';
+"import { toRefs, computed, ref } from "vue";
 type Props = {
   msg?: string;
   foo: string;

--- a/packages/vue-script-setup-converter/src/lib/convertSrc.test.ts
+++ b/packages/vue-script-setup-converter/src/lib/convertSrc.test.ts
@@ -156,13 +156,35 @@ export default defineComponent({
 </script>`);
     expect(output).toMatchInlineSnapshot(
       `
-      "import type { PropType } from 'vue';
-      import { computed } from "vue";
+      "import { computed } from "vue";
+      import type { PropType } from 'vue';
       type Props = { msg?: string; }; const props = withDefaults(defineProps<Props>(), { msg: 'HelloWorld' });
 
       const newMsg = computed(() => props.msg + '- HelloWorld');
       "
     `
     );
+  });
+
+  it("should be converted to defineAsyncComponent", () => {
+    const output = convertSrc(`<script>
+import { defineComponent } from 'vue';
+import HelloWorld from './HelloWorld.vue';
+
+export default defineComponent({
+  components: {
+    HelloWorld,
+    MyComp: () => import('./MyComp.vue'),
+    Foo: () => import('./Foo.vue'),
+  }
+  })
+  </script>`);
+    expect(output).toMatchInlineSnapshot(`
+      "import { defineAsyncComponent } from "vue";
+      import HelloWorld from './HelloWorld.vue';
+      const MyComp = defineAsyncComponent(() => import('./MyComp.vue'));
+      const Foo = defineAsyncComponent(() => import('./Foo.vue'));
+      "
+    `);
   });
 });

--- a/packages/vue-script-setup-converter/src/lib/convertSrc.test.ts
+++ b/packages/vue-script-setup-converter/src/lib/convertSrc.test.ts
@@ -122,7 +122,7 @@ export default defineComponent({
 </script>`);
     expect(output).toMatchInlineSnapshot(
       `
-      "import { toRefs, computed } from 'vue';
+      "import { toRefs, computed } from "vue";
       type Props = { msg?: string; }; const props = withDefaults(defineProps<Props>(), { msg: 'HelloWorld' });
 
       const { msg } = toRefs(props);
@@ -157,7 +157,7 @@ export default defineComponent({
     expect(output).toMatchInlineSnapshot(
       `
       "import type { PropType } from 'vue';
-      import { computed } from 'vue';
+      import { computed } from "vue";
       type Props = { msg?: string; }; const props = withDefaults(defineProps<Props>(), { msg: 'HelloWorld' });
 
       const newMsg = computed(() => props.msg + '- HelloWorld');

--- a/packages/vue-script-setup-converter/src/lib/convertSrc.ts
+++ b/packages/vue-script-setup-converter/src/lib/convertSrc.ts
@@ -15,6 +15,7 @@ import { convertProps } from "./converter/propsConverter";
 import { convertSetup } from "./converter/setupConverter";
 import { convertEmits } from "./converter/emitsConverter";
 import { convertComponents } from "./converter/componentsConverter";
+import { genImport } from "knitwork";
 
 export const convertSrc = (input: string) => {
   const {
@@ -44,14 +45,27 @@ export const convertSrc = (input: string) => {
     throw new Error("defineComponent is not found.");
   }
 
-  const importDeclaration = convertImportDeclaration(sourceFile) ?? "";
+  const importMap = convertImportDeclaration(sourceFile) ?? "";
   const pageMeta = convertPageMeta(callexpression, lang) ?? "";
   const props = convertProps(callexpression, lang) ?? "";
   const emits = convertEmits(callexpression, lang) ?? "";
   const statement = convertSetup(callexpression) ?? "";
   const components = convertComponents(callexpression) ?? "";
 
+  const hasDynamicImport = components.includes("defineAsyncComponent");
+
   const statements = project.createSourceFile("new.tsx");
+
+  if (hasDynamicImport) {
+    importMap[0].importSpecifiers.push("defineAsyncComponent");
+    statements.addStatements(
+      importMap.map((x) => genImport(x.moduleSpecifier, x.importSpecifiers))
+    );
+  } else {
+    statements.addStatements(
+      importMap.map((x) => genImport(x.moduleSpecifier, x.importSpecifiers))
+    );
+  }
 
   statements.addStatements(
     sourceFile
@@ -71,8 +85,6 @@ export const convertSrc = (input: string) => {
         return x.getText();
       })
   );
-
-  statements.addStatements(importDeclaration);
 
   if (isDefineNuxtComponent(callexpression)) {
     statements.addStatements(pageMeta);

--- a/packages/vue-script-setup-converter/src/lib/convertSrc.ts
+++ b/packages/vue-script-setup-converter/src/lib/convertSrc.ts
@@ -14,6 +14,7 @@ import { convertPageMeta } from "./converter/pageMetaConverter";
 import { convertProps } from "./converter/propsConverter";
 import { convertSetup } from "./converter/setupConverter";
 import { convertEmits } from "./converter/emitsConverter";
+import { convertComponents } from "./converter/componentsConverter";
 
 export const convertSrc = (input: string) => {
   const {
@@ -48,6 +49,7 @@ export const convertSrc = (input: string) => {
   const props = convertProps(callexpression, lang) ?? "";
   const emits = convertEmits(callexpression, lang) ?? "";
   const statement = convertSetup(callexpression) ?? "";
+  const components = convertComponents(callexpression) ?? "";
 
   const statements = project.createSourceFile("new.tsx");
 
@@ -75,6 +77,8 @@ export const convertSrc = (input: string) => {
   if (isDefineNuxtComponent(callexpression)) {
     statements.addStatements(pageMeta);
   }
+
+  statements.addStatements(components);
 
   statements.addStatements(props);
   statements.addStatements(emits);

--- a/packages/vue-script-setup-converter/src/lib/convertSrc.ts
+++ b/packages/vue-script-setup-converter/src/lib/convertSrc.ts
@@ -56,7 +56,10 @@ export const convertSrc = (input: string) => {
 
   const statements = project.createSourceFile("new.tsx");
 
-  if (hasDynamicImport) {
+  if (
+    hasDynamicImport &&
+    !importMap[0].importSpecifiers.includes("defineAsyncComponent")
+  ) {
     importMap[0].importSpecifiers.push("defineAsyncComponent");
     statements.addStatements(
       importMap.map((x) => genImport(x.moduleSpecifier, x.importSpecifiers))

--- a/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.spec.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "vitest";
+import type { CallExpression } from "ts-morph";
+import { ScriptTarget, SyntaxKind, Project } from "ts-morph";
+import { parse } from "@vue/compiler-sfc";
+import { getNodeByKind } from "../helpers/node";
+import { convertComponents } from "./componentsConverter";
+
+const parseScript = (input: string, lang: "js" | "ts" = "js") => {
+  const {
+    descriptor: { script },
+  } = parse(input);
+
+  const project = new Project({
+    tsConfigFilePath: "tsconfig.json",
+    compilerOptions: {
+      target: ScriptTarget.Latest,
+    },
+  });
+
+  const sourceFile = project.createSourceFile("s.tsx", script?.content ?? "");
+
+  const callexpression = getNodeByKind(sourceFile, SyntaxKind.CallExpression);
+
+  const components = convertComponents(callexpression as CallExpression);
+
+  return components;
+};
+
+test("should be converted to defineAsyncComponent", () => {
+  const source = `<script>
+  import { defineComponent } from 'vue';
+  import HelloWorld from './HelloWorld.vue';
+
+  export default defineComponent({
+    components: {
+      HelloWorld,
+      MyComp: () => import('./MyComp.vue'),
+      Foo: () => import('./Foo.vue'),
+    }
+  })
+  `;
+  const output = parseScript(source);
+
+  expect(output).toMatchInlineSnapshot(
+    `
+    "const MyComp = defineAsyncComponent(() => import('./MyComp.vue'))
+    const Foo = defineAsyncComponent(() => import('./Foo.vue'))"
+  `
+  );
+});

--- a/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.spec.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.spec.ts
@@ -48,3 +48,24 @@ test("should be converted to defineAsyncComponent", () => {
   `
   );
 });
+
+test("should be output as is", () => {
+  const source = `<script>
+  import { defineComponent, defineAsyncComponent } from 'vue';
+  import HelloWorld from './HelloWorld.vue';
+
+  export default defineComponent({
+    components: {
+      HelloWorld,
+      MyComp: defineAsyncComponent(() => import('./MyComp.vue')),
+      Foo: defineAsyncComponent(() => import('./Foo.vue')),
+    }
+  })
+  `;
+  const output = parseScript(source);
+
+  expect(output).toMatchInlineSnapshot(`
+    "const MyComp = defineAsyncComponent(() => import('./MyComp.vue'))
+    const Foo = defineAsyncComponent(() => import('./Foo.vue'))"
+  `);
+});

--- a/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.ts
@@ -1,0 +1,54 @@
+import type {
+  CallExpression,
+  ObjectLiteralElementLike,
+  PropertyAssignment,
+} from "ts-morph";
+import { Node, SyntaxKind } from "ts-morph";
+import { getOptionsNode } from "../helpers/node";
+
+export const convertComponents = (node: CallExpression) => {
+  const componentsNode = getOptionsNode(node, "components");
+
+  if (!componentsNode) {
+    return "";
+  }
+
+  return convertToDefineAsyncComponent(componentsNode);
+};
+
+const convertToDefineAsyncComponent = (node: PropertyAssignment) => {
+  const child = node.getInitializer();
+
+  if (!child) {
+    throw new Error("components is empty.");
+  }
+
+  if (!Node.isObjectLiteralExpression(child)) return "";
+
+  const properties = child.getProperties();
+
+  const filterdProperties = properties.filter(filterDynamicImport);
+
+  if (filterdProperties.length === 0) return "";
+
+  const value = filterdProperties
+    .map((x) => {
+      const propertyName = x.getName();
+      const arrowFunc = x.getFirstChildByKind(SyntaxKind.ArrowFunction);
+      return `const ${propertyName} = defineAsyncComponent(${arrowFunc!.getText()})`;
+    })
+    .join("\n");
+
+  return value;
+};
+
+// dynamicImportのあるPropertyAssignmentのみを抽出
+const filterDynamicImport = (
+  property: Node
+): property is PropertyAssignment => {
+  return Node.isPropertyAssignment(property) && hasDynamicImport(property);
+};
+
+const hasDynamicImport = (node: ObjectLiteralElementLike) => {
+  return node.getText().includes("() => import(");
+};

--- a/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.ts
@@ -34,6 +34,14 @@ const convertToDefineAsyncComponent = (node: PropertyAssignment) => {
   const value = filterdProperties
     .map((x) => {
       const propertyName = x.getName();
+      const initializer = x.getInitializer();
+
+      if (!initializer) return "";
+
+      if (initializer.getText().includes("defineAsyncComponent")) {
+        return `const ${propertyName} = ${initializer.getText()}`;
+      }
+
       const arrowFunc = x.getFirstChildByKind(SyntaxKind.ArrowFunction);
       return `const ${propertyName} = defineAsyncComponent(${arrowFunc!.getText()})`;
     })
@@ -42,7 +50,6 @@ const convertToDefineAsyncComponent = (node: PropertyAssignment) => {
   return value;
 };
 
-// dynamicImportのあるPropertyAssignmentのみを抽出
 const filterDynamicImport = (
   property: Node
 ): property is PropertyAssignment => {

--- a/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.ts
@@ -1,10 +1,7 @@
-import type {
-  CallExpression,
-  ObjectLiteralElementLike,
-  PropertyAssignment,
-} from "ts-morph";
+import type { CallExpression, PropertyAssignment } from "ts-morph";
 import { Node, SyntaxKind } from "ts-morph";
 import { getOptionsNode } from "../helpers/node";
+import { filterDynamicImport } from "../helpers/module";
 
 export const convertComponents = (node: CallExpression) => {
   const componentsNode = getOptionsNode(node, "components");
@@ -48,14 +45,4 @@ const convertToDefineAsyncComponent = (node: PropertyAssignment) => {
     .join("\n");
 
   return value;
-};
-
-const filterDynamicImport = (
-  property: Node
-): property is PropertyAssignment => {
-  return Node.isPropertyAssignment(property) && hasDynamicImport(property);
-};
-
-const hasDynamicImport = (node: ObjectLiteralElementLike) => {
-  return node.getText().includes("() => import(");
 };

--- a/packages/vue-script-setup-converter/src/lib/converter/importDeclarationConverter.test.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/importDeclarationConverter.test.ts
@@ -50,10 +50,12 @@ describe("convertImportDeclaration", () => {
   })
   </script>`;
 
-    it("returns blank", () => {
+    it("importSpecifiers returns blank", () => {
       const output = parseScript(source);
 
-      expect(output).toEqual([{ importSpecifiers: [], moduleSpecifier: "" }]);
+      expect(output).toEqual([
+        { importSpecifiers: [], moduleSpecifier: "vue" },
+      ]);
     });
   });
 
@@ -87,13 +89,13 @@ describe("convertImportDeclaration", () => {
   })
   </script>`;
 
-    it("returns blank", () => {
+    it("importSpecifiers returns blank", () => {
       const output = parseScript(source);
 
       expect(output).toEqual([
         {
           importSpecifiers: [],
-          moduleSpecifier: "",
+          moduleSpecifier: "#imports",
         },
       ]);
     });

--- a/packages/vue-script-setup-converter/src/lib/converter/importDeclarationConverter.test.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/importDeclarationConverter.test.ts
@@ -16,9 +16,7 @@ const parseScript = (input: string) => {
   });
 
   const sourceFile = project.createSourceFile("s.tsx", script?.content ?? "");
-  const convertedImportDeclarationText = convertImportDeclaration(sourceFile);
-
-  return convertedImportDeclarationText;
+  return convertImportDeclaration(sourceFile);
 };
 
 describe("convertImportDeclaration", () => {
@@ -34,7 +32,12 @@ describe("convertImportDeclaration", () => {
     it("returns import declaration text removed defineComponent", () => {
       const output = parseScript(source);
 
-      expect(output).toMatchInlineSnapshot(`"import { ref } from "vue";"`);
+      expect(output).toEqual([
+        {
+          importSpecifiers: ["ref"],
+          moduleSpecifier: "vue",
+        },
+      ]);
     });
   });
 
@@ -50,7 +53,7 @@ describe("convertImportDeclaration", () => {
     it("returns blank", () => {
       const output = parseScript(source);
 
-      expect(output).toBe("");
+      expect(output).toEqual([{ importSpecifiers: [], moduleSpecifier: "" }]);
     });
   });
 
@@ -66,7 +69,12 @@ describe("convertImportDeclaration", () => {
     it("returns import declaration text removed defineNuxtComponent", () => {
       const output = parseScript(source);
 
-      expect(output).toMatchInlineSnapshot(`"import { ref } from "#imports";"`);
+      expect(output).toEqual([
+        {
+          importSpecifiers: ["ref"],
+          moduleSpecifier: "#imports",
+        },
+      ]);
     });
   });
 
@@ -82,7 +90,12 @@ describe("convertImportDeclaration", () => {
     it("returns blank", () => {
       const output = parseScript(source);
 
-      expect(output).toBe("");
+      expect(output).toEqual([
+        {
+          importSpecifiers: [],
+          moduleSpecifier: "",
+        },
+      ]);
     });
   });
 });

--- a/packages/vue-script-setup-converter/src/lib/converter/importDeclarationConverter.test.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/importDeclarationConverter.test.ts
@@ -34,7 +34,7 @@ describe("convertImportDeclaration", () => {
     it("returns import declaration text removed defineComponent", () => {
       const output = parseScript(source);
 
-      expect(output).toMatchInlineSnapshot(`"import { ref } from 'vue';"`);
+      expect(output).toMatchInlineSnapshot(`"import { ref } from "vue";"`);
     });
   });
 
@@ -66,7 +66,7 @@ describe("convertImportDeclaration", () => {
     it("returns import declaration text removed defineNuxtComponent", () => {
       const output = parseScript(source);
 
-      expect(output).toMatchInlineSnapshot(`"import { ref } from '#imports';"`);
+      expect(output).toMatchInlineSnapshot(`"import { ref } from "#imports";"`);
     });
   });
 

--- a/packages/vue-script-setup-converter/src/lib/converter/importDeclarationConverter.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/importDeclarationConverter.ts
@@ -1,7 +1,13 @@
 import type { SourceFile } from "ts-morph";
-import { genImport } from "knitwork";
 
-export const convertImportDeclaration = (sourceFile: SourceFile) => {
+type ImportMap = {
+  importSpecifiers: string[];
+  moduleSpecifier: string;
+};
+
+export const convertImportDeclaration = (
+  sourceFile: SourceFile
+): ImportMap[] => {
   const importDeclarations = sourceFile.getImportDeclarations();
 
   const vueImportDeclarations = importDeclarations.filter(
@@ -14,23 +20,20 @@ export const convertImportDeclaration = (sourceFile: SourceFile) => {
     }
   );
 
-  const newVueImportDeclarations = vueImportDeclarations.map(
-    (importDeclaration) => {
-      const namedImports = importDeclaration.getNamedImports();
+  if (vueImportDeclarations.length === 0) return [];
 
-      const filteredNamedImports = namedImports
-        .map((namedImport) => namedImport.getText())
-        .filter(
-          (text) => !["defineComponent", "defineNuxtComponent"].includes(text)
-        );
-      if (filteredNamedImports.length === 0) return "";
+  return vueImportDeclarations.map((importDeclaration) => {
+    const namedImports = importDeclaration.getNamedImports();
 
-      return genImport(
-        importDeclaration.getModuleSpecifierValue(),
-        filteredNamedImports
+    const filteredNamedImports = namedImports
+      .map((namedImport) => namedImport.getText())
+      .filter(
+        (text) => !["defineComponent", "defineNuxtComponent"].includes(text)
       );
-    }
-  );
 
-  return newVueImportDeclarations.join("\n");
+    return {
+      importSpecifiers: filteredNamedImports,
+      moduleSpecifier: importDeclaration.getModuleSpecifierValue(),
+    };
+  });
 };

--- a/packages/vue-script-setup-converter/src/lib/converter/importDeclarationConverter.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/importDeclarationConverter.ts
@@ -1,4 +1,5 @@
 import type { ImportDeclaration, SourceFile } from "ts-morph";
+import { genImport } from "knitwork";
 import { hasNamedImportIdentifier } from "../helpers/module";
 
 export const convertImportDeclaration = (sourceFile: SourceFile) => {
@@ -33,7 +34,8 @@ const convertToImportDeclarationText = (
 
   if (filteredNamedImports.length === 0) return "";
 
-  return `import { ${filteredNamedImports.join(
-    ", "
-  )} } from '${importDeclaration.getModuleSpecifierValue()}';`;
+  return genImport(
+    importDeclaration.getModuleSpecifierValue(),
+    filteredNamedImports
+  );
 };

--- a/packages/vue-script-setup-converter/src/lib/helpers/module.ts
+++ b/packages/vue-script-setup-converter/src/lib/helpers/module.ts
@@ -1,4 +1,9 @@
-import type { ImportDeclaration } from "ts-morph";
+import type {
+  ImportDeclaration,
+  ObjectLiteralElementLike,
+  PropertyAssignment,
+} from "ts-morph";
+import { Node } from "ts-morph";
 
 export const hasNamedImportIdentifier = (
   importDeclaration: ImportDeclaration,
@@ -9,4 +14,14 @@ export const hasNamedImportIdentifier = (
       return namedImport.getName() === identifier;
     })
   );
+};
+
+export const filterDynamicImport = (
+  property: Node
+): property is PropertyAssignment => {
+  return Node.isPropertyAssignment(property) && hasDynamicImport(property);
+};
+
+export const hasDynamicImport = (node: ObjectLiteralElementLike) => {
+  return node.getText().includes("() => import(");
 };

--- a/packages/vue-script-setup-converter/src/lib/helpers/node.ts
+++ b/packages/vue-script-setup-converter/src/lib/helpers/node.ts
@@ -17,7 +17,7 @@ export const getNodeByKind = (
 
 export const getOptionsNode = (
   node: CallExpression,
-  type: "name" | "layout" | "middleware" | "props" | "emits"
+  type: "name" | "layout" | "middleware" | "props" | "emits" | "components"
 ) => {
   const expression = getNodeByKind(node, SyntaxKind.ObjectLiteralExpression);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       '@wattanx/converter-utils':
         specifier: workspace:*
         version: link:../converter-utils
+      knitwork:
+        specifier: ^1.1.0
+        version: 1.1.0
       ts-morph:
         specifier: '>=17.0.1'
         version: 17.0.1
@@ -5625,6 +5628,10 @@ packages:
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /knitwork@1.1.0:
+    resolution: {integrity: sha512-oHnmiBUVHz1V+URE77PNot2lv3QiYU2zQf1JjOVkMt3YDKGbu8NAFr+c4mcNOhdsGrB/VpVbRwPwhiXrPhxQbw==}
     dev: false
 
   /language-subtag-registry@0.3.22:


### PR DESCRIPTION
- If `defineAsyncComponent` is not used, convert to use `defineAsyncComponent`
- If `defineAsyncComponent` is already in use, use it as is.