### PR TITLE
fix(vue-script-setup-converter): Components converter fails if dynamic imports contain newlines

### DIFF
--- a/packages/vue-script-setup-converter/src/lib/convertSrc.ts
+++ b/packages/vue-script-setup-converter/src/lib/convertSrc.ts
@@ -89,11 +89,11 @@ export const convertSrc = (input: string) => {
       })
   );
 
+  statements.addStatements(components);
+
   if (isDefineNuxtComponent(callexpression)) {
     statements.addStatements(pageMeta);
   }
-
-  statements.addStatements(components);
 
   statements.addStatements(props);
   statements.addStatements(emits);

--- a/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.spec.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.spec.ts
@@ -35,7 +35,8 @@ test("should be converted to defineAsyncComponent", () => {
     components: {
       HelloWorld,
       MyComp: () => import('./MyComp.vue'),
-      Foo: () => import('./Foo.vue'),
+      Foo: () =>
+        import('./Foo.vue'),
     }
   })
   `;

--- a/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.spec.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.spec.ts
@@ -60,7 +60,8 @@ test("should be output as is", () => {
     components: {
       HelloWorld,
       MyComp: defineAsyncComponent(() => import('./MyComp.vue')),
-      Foo: defineAsyncComponent(() => import('./Foo.vue')),
+      Foo: defineAsyncComponent(() =>
+        import('./Foo.vue')),
     }
   })
   `;
@@ -68,6 +69,7 @@ test("should be output as is", () => {
 
   expect(output).toMatchInlineSnapshot(`
     "const MyComp = defineAsyncComponent(() => import('./MyComp.vue'))
-    const Foo = defineAsyncComponent(() => import('./Foo.vue'))"
+    const Foo = defineAsyncComponent(() =>
+            import('./Foo.vue'))"
   `);
 });

--- a/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.spec.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.spec.ts
@@ -45,7 +45,8 @@ test("should be converted to defineAsyncComponent", () => {
   expect(output).toMatchInlineSnapshot(
     `
     "const MyComp = defineAsyncComponent(() => import('./MyComp.vue'))
-    const Foo = defineAsyncComponent(() => import('./Foo.vue'))"
+    const Foo = defineAsyncComponent(() =>
+            import('./Foo.vue'))"
   `
   );
 });

--- a/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.ts
+++ b/packages/vue-script-setup-converter/src/lib/converter/componentsConverter.ts
@@ -24,11 +24,11 @@ const convertToDefineAsyncComponent = (node: PropertyAssignment) => {
 
   const properties = child.getProperties();
 
-  const filterdProperties = properties.filter(filterDynamicImport);
+  const filteredProperties = properties.filter(filterDynamicImport);
 
-  if (filterdProperties.length === 0) return "";
+  if (filteredProperties.length === 0) return "";
 
-  const value = filterdProperties
+  const value = filteredProperties
     .map((x) => {
       const propertyName = x.getName();
       const initializer = x.getInitializer();

--- a/packages/vue-script-setup-converter/src/lib/helpers/module.ts
+++ b/packages/vue-script-setup-converter/src/lib/helpers/module.ts
@@ -23,5 +23,5 @@ export const filterDynamicImport = (
 };
 
 export const hasDynamicImport = (node: ObjectLiteralElementLike) => {
-  return node.getText().includes("() => import(");
+  return node.getText().includes("import(");
 };

--- a/packages/vue-script-setup-converter/src/lib/helpers/module.ts
+++ b/packages/vue-script-setup-converter/src/lib/helpers/module.ts
@@ -3,7 +3,7 @@ import type {
   ObjectLiteralElementLike,
   PropertyAssignment,
 } from "ts-morph";
-import { Node, SyntaxKind } from "ts-morph";
+import { Node } from "ts-morph";
 
 export const hasNamedImportIdentifier = (
   importDeclaration: ImportDeclaration,
@@ -23,7 +23,5 @@ export const filterDynamicImport = (
 };
 
 export const hasDynamicImport = (node: ObjectLiteralElementLike) => {
-  const arrowFunction = node.getFirstChildByKind(SyntaxKind.ArrowFunction);
-  if (!arrowFunction) return false;
-  return arrowFunction.getText().includes("() => import(");
+  return node.getText().includes("() => import(");
 };

--- a/packages/vue-script-setup-converter/src/lib/helpers/module.ts
+++ b/packages/vue-script-setup-converter/src/lib/helpers/module.ts
@@ -3,7 +3,7 @@ import type {
   ObjectLiteralElementLike,
   PropertyAssignment,
 } from "ts-morph";
-import { Node } from "ts-morph";
+import { Node, SyntaxKind } from "ts-morph";
 
 export const hasNamedImportIdentifier = (
   importDeclaration: ImportDeclaration,
@@ -23,5 +23,7 @@ export const filterDynamicImport = (
 };
 
 export const hasDynamicImport = (node: ObjectLiteralElementLike) => {
-  return node.getText().includes("() => import(");
+  const arrowFunction = node.getFirstChildByKind(SyntaxKind.ArrowFunction);
+  if (!arrowFunction) return false;
+  return arrowFunction.getText().includes("() => import(");
 };


### PR DESCRIPTION
## Problem to be solved

Components converter fails if dynamic imports contain newlines.

examples:  [test: Conversion fails if dynamic imports contain newlines](https://github.com/wattanx/wattanx-converter/pull/60/commits/da30a48090d6c95c3cfe834a74041f588dd18853)
